### PR TITLE
feat: case of fail navigator geolocation

### DIFF
--- a/src/components/SearchBox.js
+++ b/src/components/SearchBox.js
@@ -78,9 +78,12 @@ export const SearchBox = ({ onWeatherInput, setLoadingCity }) => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
         const { latitude, longitude } = position.coords;
-        onWeatherInput(`${latitude},${longitude}`);
+          onWeatherInput(`${latitude},${longitude}`);
+      }, (error) => {
+          //in case of user denied hide loading skeleton
+          setLoadingCity(false);
       });
-    }
+      }
   };
 
   return (


### PR DESCRIPTION
Si la geolocalisation plante ou est refusé par l utilisateur le loading skeleton ne reste plus à l'écran.